### PR TITLE
Centralize Supabase client bootstrap

### DIFF
--- a/auth/register.html
+++ b/auth/register.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>Register — Memoir</title>
   <link rel="stylesheet" href="/styles.css">
+  <script src="/js/memoir-supabase.js"></script>
 </head>
 <body>
   <main style="display:flex;flex-direction:column;gap:12px;align-items:center;justify-content:center;height:100vh;text-align:center;">
@@ -23,44 +24,60 @@
     </form>
   </main>
 
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script>
-    const SUPABASE_URL = "https://fswxkujxusdozvmpyvzk.supabase.co"; // replace
-    const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZzd3hrdWp4dXNkb3p2bXB5dnprIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTgxMTk3MTYsImV4cCI6MjA3MzY5NTcxNn0.kNodFgDXi32w456e475fXvBi9eehX50HX_hVVTDBtXI";                   // replace
-    const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
-
-    document.getElementById('register-form').addEventListener('submit', async (e)=>{
-      e.preventDefault();
+    (async function(){
       const status = document.getElementById('reg-status');
-      status.textContent = 'Creating account…';
-
-      const name = document.getElementById('name').value.trim();
-      const email = document.getElementById('email').value.trim();
-      const password = document.getElementById('password').value;
-      const subscription = document.getElementById('subscription').value;
-
-      try{
-        const { data, error } = await supabase.auth.signUp({
-          email, password,
-          options: { emailRedirectTo: "https://www.memoirapp.co/auth/sign-in.html" }
-        });
-        if (error) throw error;
-
-        const userId = data?.user?.id;
-        if (userId){
-          // Insert profile row that stores name + plan
-          const { error: pErr } = await supabase.from('profiles').insert({
-            id: userId, name, subscription_type: subscription
-          });
-          if (pErr) throw pErr;
-        }
-
-        status.textContent = "Account created! Check your email to confirm, then sign in.";
-        setTimeout(()=>location.href="/auth/sign-in.html", 1200);
-      }catch(err){
-        status.textContent = err.message || "Something went wrong.";
+      const ensure = window.memoirEnsureSupabase ? window.memoirEnsureSupabase() : Promise.resolve(window.supabase);
+      let supabase;
+      try {
+        await ensure;
+        const createClient = window.memoirCreateSupabaseClient;
+        supabase = createClient
+          ? createClient()
+          : window.supabase.createClient(
+              window.MEMOIR_SUPABASE_URL || window.SUPABASE_URL,
+              window.MEMOIR_SUPABASE_ANON || window.SUPABASE_ANON_KEY
+            );
+      } catch (err) {
+        console.error('[register] supabase failed to load', err);
+        if (status) status.textContent = 'Unable to connect. Please refresh the page.';
+        return;
       }
-    });
+
+      document.getElementById('register-form').addEventListener('submit', async (e)=>{
+        e.preventDefault();
+        status.textContent = 'Creating account…';
+
+        const name = document.getElementById('name').value.trim();
+        const email = document.getElementById('email').value.trim();
+        const password = document.getElementById('password').value;
+        const subscription = document.getElementById('subscription').value;
+
+        try{
+          const { data, error } = await supabase.auth.signUp({
+            email, password,
+            options: { emailRedirectTo: `${location.origin}/auth/sign-in.html` }
+          });
+          if (error) throw error;
+
+          const userId = data?.user?.id;
+          if (userId){
+            const { error: pErr } = await supabase.from('profiles').insert({
+              user_id: userId,
+              full_name: name,
+              subscription_plan: subscription
+            });
+            if (pErr) throw pErr;
+          }
+
+          status.textContent = 'Account created! Check your email to confirm, then sign in.';
+          setTimeout(()=>location.href='/auth/sign-in.html', 1200);
+        }catch(err){
+          status.textContent = err.message || 'Something went wrong.';
+        }
+      });
+    })();
   </script>
+
 </body>
 </html>

--- a/auth/request-reset.html
+++ b/auth/request-reset.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>Reset password — Memoir</title>
   <link rel="stylesheet" href="/styles.css"/>
+  <script src="/js/memoir-supabase.js"></script>
 </head>
 <body>
   <div id="site-header"></div>
@@ -22,26 +23,44 @@
 
   <div id="site-footer"></div>
 
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/js/header-loader.js"></script>
   <script src="/js/footer-loader.js"></script>
   <script>
-    const supabase = window.supabase.createClient(window.MEMOIR_SUPABASE_URL, window.MEMOIR_SUPABASE_ANON);
-    document.getElementById('req-form').addEventListener('submit', async (e)=>{
-      e.preventDefault();
-      const status = document.getElementById('status');
-      const email  = document.getElementById('email').value.trim();
-      status.textContent = 'Sending…';
-      try{
-        const { error } = await supabase.auth.resetPasswordForEmail(email, {
-          redirectTo: location.origin + '/auth/reset-password.html'
-        });
-        if (error) throw error;
-        status.textContent = 'Check your inbox for a reset link.';
-      }catch(err){
-        status.textContent = err.message || 'Could not send reset email.';
+    (async function(){
+      const statusEl = document.getElementById('status');
+      const ensure = window.memoirEnsureSupabase ? window.memoirEnsureSupabase() : Promise.resolve(window.supabase);
+      let supabase;
+      try {
+        await ensure;
+        const createClient = window.memoirCreateSupabaseClient;
+        supabase = createClient
+          ? createClient()
+          : window.supabase.createClient(
+              window.MEMOIR_SUPABASE_URL || window.SUPABASE_URL,
+              window.MEMOIR_SUPABASE_ANON || window.SUPABASE_ANON_KEY
+            );
+      } catch (err) {
+        console.error('[request-reset] supabase failed to load', err);
+        if (statusEl) statusEl.textContent = 'Unable to connect. Please refresh the page.';
+        return;
       }
-    });
+
+      document.getElementById('req-form').addEventListener('submit', async (e)=>{
+        e.preventDefault();
+        const status = document.getElementById('status');
+        const email  = document.getElementById('email').value.trim();
+        status.textContent = 'Sending…';
+        try{
+          const { error } = await supabase.auth.resetPasswordForEmail(email, {
+            redirectTo: location.origin + '/auth/reset-password.html'
+          });
+          if (error) throw error;
+          status.textContent = 'Check your inbox for a reset link.';
+        }catch(err){
+          status.textContent = err.message || 'Could not send reset email.';
+        }
+      });
+    })();
   </script>
 </body>
 </html>

--- a/auth/reset-password.html
+++ b/auth/reset-password.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>Set new password — Memoir</title>
   <link rel="stylesheet" href="/styles.css"/>
+  <script src="/js/memoir-supabase.js"></script>
 </head>
 <body>
   <div id="site-header"></div>
@@ -23,36 +24,51 @@
 
   <div id="site-footer"></div>
 
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/js/header-loader.js"></script>
   <script src="/js/footer-loader.js"></script>
   <script>
-    const supabase = window.supabase.createClient(window.MEMOIR_SUPABASE_URL, window.MEMOIR_SUPABASE_ANON);
-    const status = document.getElementById('status');
-
-    // When user lands here from email link, Supabase will set a "recovery" session.
-    supabase.auth.onAuthStateChange(async (event, session) => {
-      if (event === 'PASSWORD_RECOVERY') {
-        status.textContent = 'Please enter a new password.';
+    (async function(){
+      const status = document.getElementById('status');
+      const ensure = window.memoirEnsureSupabase ? window.memoirEnsureSupabase() : Promise.resolve(window.supabase);
+      let supabase;
+      try {
+        await ensure;
+        const createClient = window.memoirCreateSupabaseClient;
+        supabase = createClient
+          ? createClient()
+          : window.supabase.createClient(
+              window.MEMOIR_SUPABASE_URL || window.SUPABASE_URL,
+              window.MEMOIR_SUPABASE_ANON || window.SUPABASE_ANON_KEY
+            );
+      } catch (err) {
+        console.error('[reset-password] supabase failed to load', err);
+        if (status) status.textContent = 'Unable to connect. Please refresh the page.';
+        return;
       }
-    });
 
-    document.getElementById('newpass-form').addEventListener('submit', async (e)=>{
-      e.preventDefault();
-      const p1 = document.getElementById('password').value;
-      const p2 = document.getElementById('password2').value;
-      if (p1 !== p2) { status.textContent = 'Passwords do not match.'; return; }
+      supabase.auth.onAuthStateChange(async (event) => {
+        if (event === 'PASSWORD_RECOVERY') {
+          status.textContent = 'Please enter a new password.';
+        }
+      });
 
-      status.textContent = 'Updating…';
-      try{
-        const { data, error } = await supabase.auth.updateUser({ password: p1 });
-        if (error) throw error;
-        status.textContent = 'Password updated. Redirecting to login…';
-        setTimeout(()=> location.href = '/LOGIN.html', 1200);
-      }catch(err){
-        status.textContent = err.message || 'Could not update password.';
-      }
-    });
+      document.getElementById('newpass-form').addEventListener('submit', async (e)=>{
+        e.preventDefault();
+        const p1 = document.getElementById('password').value;
+        const p2 = document.getElementById('password2').value;
+        if (p1 !== p2) { status.textContent = 'Passwords do not match.'; return; }
+
+        status.textContent = 'Updating…';
+        try{
+          const { error } = await supabase.auth.updateUser({ password: p1 });
+          if (error) throw error;
+          status.textContent = 'Password updated. Redirecting to login…';
+          setTimeout(()=> location.href = '/login.html', 1200);
+        }catch(err){
+          status.textContent = err.message || 'Could not update password.';
+        }
+      });
+    })();
   </script>
 </body>
 </html>

--- a/auth/sign-in.html
+++ b/auth/sign-in.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>Sign in — Memoir</title>
   <link rel="stylesheet" href="/styles.css">
+  <script src="/js/memoir-supabase.js"></script>
 </head>
 <body>
   <main style="display:flex;flex-direction:column;gap:12px;align-items:center;justify-content:center;height:100vh;text-align:center;">
@@ -17,27 +18,41 @@
     </form>
   </main>
 
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script>
-    // TODO: replace with your project values
-    const SUPABASE_URL = "https://fswxkujxusdozvmpyvzk.supabase.co";
-    const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZzd3hrdWp4dXNkb3p2bXB5dnprIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTgxMTk3MTYsImV4cCI6MjA3MzY5NTcxNn0.kNodFgDXi32w456e475fXvBi9eehX50HX_hVVTDBtXI";
-    const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
-
-    document.getElementById('signin-form').addEventListener('submit', async (e)=>{
-      e.preventDefault();
+    (async function(){
       const status = document.getElementById('signin-status');
-      status.textContent = 'Signing in…';
-      const email = document.getElementById('email').value.trim();
-      const password = document.getElementById('password').value;
-      try{
-        const { error } = await supabase.auth.signInWithPassword({ email, password });
-        if (error) throw error;
-        location.href = "/stories.html"; // your app entry
-      }catch(err){
-        status.textContent = err.message || "Unable to sign in.";
+      const ensure = window.memoirEnsureSupabase ? window.memoirEnsureSupabase() : Promise.resolve(window.supabase);
+      let supabase;
+      try {
+        await ensure;
+        const createClient = window.memoirCreateSupabaseClient;
+        supabase = createClient
+          ? createClient()
+          : window.supabase.createClient(
+              window.MEMOIR_SUPABASE_URL || window.SUPABASE_URL,
+              window.MEMOIR_SUPABASE_ANON || window.SUPABASE_ANON_KEY
+            );
+      } catch (err) {
+        console.error('[sign-in] supabase failed to load', err);
+        if (status) status.textContent = 'Unable to connect. Please refresh the page.';
+        return;
       }
-    });
+
+      document.getElementById('signin-form').addEventListener('submit', async (e)=>{
+        e.preventDefault();
+        status.textContent = 'Signing in…';
+        const email = document.getElementById('email').value.trim();
+        const password = document.getElementById('password').value;
+        try{
+          const { error } = await supabase.auth.signInWithPassword({ email, password });
+          if (error) throw error;
+          location.href = '/stories.html';
+        }catch(err){
+          status.textContent = err.message || 'Unable to sign in.';
+        }
+      });
+    })();
   </script>
+
 </body>
 </html>

--- a/js/header-loader.js
+++ b/js/header-loader.js
@@ -78,10 +78,14 @@
   }
 
   // ---- Session pill with Supabase ----
-  const SUPA_URL = window.MEMOIR_SUPABASE_URL || "https://fswxkujxusdozvmpyvzk.supabase.co";
-  const SUPA_KEY = window.MEMOIR_SUPABASE_ANON || "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZzd3hrdWp4dXNkb3p2bXB5dnprIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTgxMTk3MTYsImV4cCI6MjA3MzY5NTcxNn0.kNodFgDXi32w456e475fXvBi9eehX50HX_hVVTDBtXI";
+  const SUPA_URL = window.MEMOIR_SUPABASE_URL || window.SUPABASE_URL || "https://fswxkujxusdozvmpyvzk.supabase.co";
+  const SUPA_KEY = window.MEMOIR_SUPABASE_ANON || window.SUPABASE_ANON_KEY || "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZzd3hrdWp4dXNkb3p2bXB5dnprIiwicm9zZSI6ImFub24iLCJpYXQiOjE3NTgxMTk3MTYsImV4cCI6MjA3MzY5NTcxNn0.kNodFgDXi32w456e475fXvBi9eehX50HX_hVVTDBtXI";
 
   async function ensureSupabase() {
+    if (window.memoirEnsureSupabase) {
+      await window.memoirEnsureSupabase();
+      return;
+    }
     if (window.supabase && window.supabase.createClient) return;
     await new Promise((resolve, reject) => {
       const s = document.createElement('script');
@@ -108,9 +112,12 @@
     try {
       await ensureSupabase();
       if (!sb) {
-        sb = window.supabase.createClient(SUPA_URL, SUPA_KEY, {
-          auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true }
-        });
+        const create = window.memoirCreateSupabaseClient;
+        sb = create
+          ? create({ auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true } })
+          : window.supabase.createClient(SUPA_URL, SUPA_KEY, {
+              auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true }
+            });
         // react to state changes
         sb.auth.onAuthStateChange(() => renderSession());
       }

--- a/js/memoir-supabase.js
+++ b/js/memoir-supabase.js
@@ -1,0 +1,42 @@
+(function(global){
+  const DEFAULT_URL = 'https://fswxkujxusdozvmpyvzk.supabase.co';
+  const DEFAULT_ANON = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZzd3hrdWp4dXNkb3p2bXB5dnprIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTgxMTk3MTYsImV4cCI6MjA3MzY5NTcxNn0.kNodFgDXi32w456e475fXvBi9eehX50HX_hVVTDBtXI';
+
+  const url = global.MEMOIR_SUPABASE_URL || DEFAULT_URL;
+  const anon = global.MEMOIR_SUPABASE_ANON || DEFAULT_ANON;
+
+  global.MEMOIR_SUPABASE_URL = url;
+  global.MEMOIR_SUPABASE_ANON = anon;
+  global.SUPABASE_URL = global.SUPABASE_URL || url;
+  global.SUPABASE_ANON_KEY = global.SUPABASE_ANON_KEY || anon;
+
+  let loaderPromise = null;
+  function loadLibrary(){
+    if (global.supabase?.createClient) return Promise.resolve(global.supabase);
+    if (loaderPromise) return loaderPromise;
+    loaderPromise = new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2';
+      script.async = true;
+      script.onload = () => resolve(global.supabase);
+      script.onerror = (err) => {
+        loaderPromise = null;
+        reject(err || new Error('Failed to load supabase-js'));
+      };
+      document.head.appendChild(script);
+    });
+    return loaderPromise;
+  }
+
+  global.memoirEnsureSupabase = loadLibrary;
+  global.memoirCreateSupabaseClient = function(options){
+    if (!global.supabase?.createClient) {
+      throw new Error('Supabase JS has not been loaded yet. Call memoirEnsureSupabase() first.');
+    }
+    return global.supabase.createClient(url, anon, options);
+  };
+
+  if (global.supabase?.createClient) {
+    loaderPromise = Promise.resolve(global.supabase);
+  }
+})(window);

--- a/landing.html
+++ b/landing.html
@@ -8,6 +8,9 @@
   <!-- Global styles -->
   <link rel="stylesheet" href="/styles.css"/>
 
+  <!-- Shared Supabase config -->
+  <script src="/js/memoir-supabase.js"></script>
+
   <!-- Page-scoped additions -->
   <style>
     :root{

--- a/login.html
+++ b/login.html
@@ -39,12 +39,8 @@
       background:#e9f7ef; color:#1b5e20; border:1px solid #c7ebd2; display:none}
   </style>
 
-  <!-- Supabase project -->
-  <script>
-    window.MEMOIR_SUPABASE_URL  = "https://fswxkujxusdozvmpyvzk.supabase.co";
-    window.MEMOIR_SUPABASE_ANON = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZzd3hrdWp4dXNkb3p2bXB5dnprIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTgxMTk3MTYsImV4cCI6MjA3MzY5NTcxNn0.kNodFgDXi32w456e475fXvBi9eehX50HX_hVVTDBtXI";
-  </script>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <!-- Shared Supabase config -->
+  <script src="/js/memoir-supabase.js"></script>
 </head>
 <body>
   <div id="site-header"></div>
@@ -143,128 +139,146 @@
 
   <script src="/js/header-loader.js"></script>
   <script src="/js/footer-loader.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script>
-    const SB = supabase.createClient(
-      window.MEMOIR_SUPABASE_URL,
-      window.MEMOIR_SUPABASE_ANON,
-      { auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true } }
-    );
-
-    // Confirmation / recovery banner
     (async function(){
-      const n = document.getElementById('topNotice');
-      const hash = location.hash || '';
-      if (hash.includes('type=signup')) {
-        const { data: { user } } = await SB.auth.getUser();
-        n.textContent = user ? 'Email confirmed — you are signed in.' : 'Email confirmed — you can sign in now.';
-        n.style.display = 'block';
-        if (user) setTimeout(()=> location.href='/settings.html', 1200);
-      } else if (hash.includes('type=recovery')) {
-        n.textContent = 'Open this page to set a new password (Settings will reflect the change).';
-        n.style.display = 'block';
-      }
-    })();
-
-    // Toggle panels
-    const regPanel   = document.getElementById('registerPanel');
-    const resetPanel = document.getElementById('resetPanel');
-    document.getElementById('toggleRegister').addEventListener('click', ()=>{
-      const open = regPanel.classList.toggle('open');
-      regPanel.setAttribute('aria-hidden', String(!open));
-      if(open) document.getElementById('reg_first').focus();
-    });
-    document.getElementById('toggleReset').addEventListener('click', ()=>{
-      const open = resetPanel.classList.toggle('open');
-      resetPanel.setAttribute('aria-hidden', String(!open));
-      if(open) document.getElementById('reset_email').focus();
-    });
-    document.getElementById('closeReset').addEventListener('click', ()=>{
-      resetPanel.classList.remove('open'); resetPanel.setAttribute('aria-hidden','true');
-    });
-
-    // Sign in
-    (function(){
-      const form = document.getElementById('loginForm');
-      const err  = document.getElementById('loginError');
-      const btn  = document.getElementById('loginSubmit');
-      form.addEventListener('submit', async (e)=>{
-        e.preventDefault(); err.textContent=''; btn.disabled=true; btn.setAttribute('aria-busy','true');
-        try{
-          const email    = document.getElementById('identifier').value.trim();
-          const password = document.getElementById('password').value;
-          if(!email || !password){ err.textContent='Please fill email and password.'; return; }
-          const { error } = await SB.auth.signInWithPassword({ email, password });
-          if (error) throw error;
-          location.href = '/settings.html';
-        }catch(ex){ err.textContent = ex?.message || 'Sign in failed. Please try again.'; }
-        finally{ btn.disabled=false; btn.removeAttribute('aria-busy'); }
-      });
-    })();
-
-    // Register — replace the whole panel with a success block
-    (function(){
-      const form = document.getElementById('registerForm');
-      const panel = document.getElementById('registerPanel');
-      const err  = document.getElementById('registerError');
-      const btn  = document.getElementById('registerSubmit');
-
-      form.addEventListener('submit', async (e)=>{
-        e.preventDefault(); err.textContent=''; err.style.color='#a23a3a';
-        btn.disabled=true; btn.setAttribute('aria-busy','true');
-        try{
-          const first     = document.getElementById('reg_first').value.trim();
-          const last      = document.getElementById('reg_last').value.trim();
-          const email     = document.getElementById('reg_email').value.trim();
-          const password  = document.getElementById('reg_password').value;
-          const plan      = document.getElementById('reg_plan').value;
-          const gdprOk    = document.getElementById('reg_gdpr').checked;
-          if(!gdprOk){ err.textContent='Please agree to the Terms and Privacy Policy.'; return; }
-          const full_name = `${first} ${last}`.trim();
-
-          const { error } = await SB.auth.signUp({
-            email, password,
-            options: {
-              emailRedirectTo: location.origin + '/login.html#type=signup',
-              data: { first_name:first, last_name:last, full_name, subscription_plan: plan, gdpr_consent: true }
-            }
-          });
-          if (error) throw error;
-
-          // Replace the entire register panel with a big success message
-          panel.classList.add('open'); // ensure it's visible
-          panel.setAttribute('aria-hidden','false');
-          panel.innerHTML = `
-            <div class="card" style="background:#e9f7ef;border-color:#c7ebd2">
-              <h2 class="title" style="font-size:22px;margin:0 0 8px;">Account created</h2>
-              <p class="helper" style="color:#1b5e20">Please check your email to confirm your account. After confirming, you’ll be signed in automatically.</p>
-              <div class="actions" style="margin-top:10px">
-                <a class="btn primary" href="/login.html">Back to sign in</a>
-              </div>
-            </div>
-          `;
-          window.scrollTo({ top: panel.offsetTop - 20, behavior: 'smooth' });
-        }catch(ex){
-          err.textContent = ex?.message || 'Registration failed.';
-        }finally{
-          btn.disabled=false; btn.removeAttribute('aria-busy');
+      const ensure = window.memoirEnsureSupabase ? window.memoirEnsureSupabase() : Promise.resolve(window.supabase);
+      try {
+        await ensure;
+      } catch (err) {
+        console.error('[login] supabase failed to load', err);
+        const loginError = document.getElementById('loginError');
+        if (loginError) {
+          loginError.textContent = 'Unable to connect to the login service. Please refresh the page.';
         }
-      });
-    })();
+        return;
+      }
 
-    // Reset
-    (function(){
-      const form = document.getElementById('resetForm');
-      const msg  = document.getElementById('resetMsg');
-      form.addEventListener('submit', async (e)=>{
-        e.preventDefault(); msg.textContent='Sending…';
-        try{
-          const email = document.getElementById('reset_email').value.trim();
-          const { error } = await SB.auth.resetPasswordForEmail(email, { redirectTo: location.origin + '/login.html#type=recovery' });
-          if (error) throw error;
-          msg.textContent = 'Check your inbox for a reset link.';
-        }catch(ex){ msg.textContent = ex?.message || 'Could not send reset email.'; }
+      const createClient = window.memoirCreateSupabaseClient;
+      const SB = createClient
+        ? createClient({ auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true } })
+        : window.supabase.createClient(
+            window.MEMOIR_SUPABASE_URL || window.SUPABASE_URL,
+            window.MEMOIR_SUPABASE_ANON || window.SUPABASE_ANON_KEY,
+            { auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true } }
+          );
+
+      window.MEMOIR_SUPABASE_CLIENT = SB;
+
+      // Confirmation / recovery banner
+      (async function(){
+        const n = document.getElementById('topNotice');
+        const hash = location.hash || '';
+        if (hash.includes('type=signup')) {
+          const { data: { user } } = await SB.auth.getUser();
+          n.textContent = user ? 'Email confirmed — you are signed in.' : 'Email confirmed — you can sign in now.';
+          n.style.display = 'block';
+          if (user) setTimeout(()=> location.href='/settings.html', 1200);
+        } else if (hash.includes('type=recovery')) {
+          n.textContent = 'Open this page to set a new password (Settings will reflect the change).';
+          n.style.display = 'block';
+        }
+      })();
+
+      // Toggle panels
+      const regPanel   = document.getElementById('registerPanel');
+      const resetPanel = document.getElementById('resetPanel');
+      document.getElementById('toggleRegister').addEventListener('click', ()=>{
+        const open = regPanel.classList.toggle('open');
+        regPanel.setAttribute('aria-hidden', String(!open));
+        if(open) document.getElementById('reg_first').focus();
       });
+      document.getElementById('toggleReset').addEventListener('click', ()=>{
+        const open = resetPanel.classList.toggle('open');
+        resetPanel.setAttribute('aria-hidden', String(!open));
+        if(open) document.getElementById('reset_email').focus();
+      });
+      document.getElementById('closeReset').addEventListener('click', ()=>{
+        resetPanel.classList.remove('open'); resetPanel.setAttribute('aria-hidden','true');
+      });
+
+      // Sign in
+      (function(){
+        const form = document.getElementById('loginForm');
+        const err  = document.getElementById('loginError');
+        const btn  = document.getElementById('loginSubmit');
+        form.addEventListener('submit', async (e)=>{
+          e.preventDefault(); err.textContent=''; btn.disabled=true; btn.setAttribute('aria-busy','true');
+          try{
+            const email    = document.getElementById('identifier').value.trim();
+            const password = document.getElementById('password').value;
+            if(!email || !password){ err.textContent='Please fill email and password.'; return; }
+            const { error } = await SB.auth.signInWithPassword({ email, password });
+            if (error) throw error;
+            location.href = '/settings.html';
+          }catch(ex){ err.textContent = ex?.message || 'Sign in failed. Please try again.'; }
+          finally{ btn.disabled=false; btn.removeAttribute('aria-busy'); }
+        });
+      })();
+
+      // Register — replace the whole panel with a success block
+      (function(){
+        const form = document.getElementById('registerForm');
+        const panel = document.getElementById('registerPanel');
+        const err  = document.getElementById('registerError');
+        const btn  = document.getElementById('registerSubmit');
+
+        form.addEventListener('submit', async (e)=>{
+          e.preventDefault(); err.textContent=''; err.style.color='#a23a3a';
+          btn.disabled=true; btn.setAttribute('aria-busy','true');
+          try{
+            const first     = document.getElementById('reg_first').value.trim();
+            const last      = document.getElementById('reg_last').value.trim();
+            const email     = document.getElementById('reg_email').value.trim();
+            const password  = document.getElementById('reg_password').value;
+            const plan      = document.getElementById('reg_plan').value;
+            const gdprOk    = document.getElementById('reg_gdpr').checked;
+            if(!gdprOk){ err.textContent='Please agree to the Terms and Privacy Policy.'; return; }
+            const full_name = `${first} ${last}`.trim();
+
+            const { error } = await SB.auth.signUp({
+              email, password,
+              options: {
+                emailRedirectTo: location.origin + '/login.html#type=signup',
+                data: { first_name:first, last_name:last, full_name, subscription_plan: plan, gdpr_consent: true }
+              }
+            });
+            if (error) throw error;
+
+            // Replace the entire register panel with a big success message
+            panel.classList.add('open'); // ensure it's visible
+            panel.setAttribute('aria-hidden','false');
+            panel.innerHTML = `
+              <div class="card" style="background:#e9f7ef;border-color:#c7ebd2">
+                <h2 class="title" style="font-size:22px;margin:0 0 8px;">Account created</h2>
+                <p class="helper" style="color:#1b5e20">Please check your email to confirm your account. After confirming, you’ll be signed in automatically.</p>
+                <div class="actions" style="margin-top:10px">
+                  <a class="btn primary" href="/login.html">Back to sign in</a>
+                </div>
+              </div>
+            `;
+            window.scrollTo({ top: panel.offsetTop - 20, behavior: 'smooth' });
+          }catch(ex){
+            err.textContent = ex?.message || 'Registration failed.';
+          }finally{
+            btn.disabled=false; btn.removeAttribute('aria-busy');
+          }
+        });
+      })();
+
+      // Reset
+      (function(){
+        const form = document.getElementById('resetForm');
+        const msg  = document.getElementById('resetMsg');
+        form.addEventListener('submit', async (e)=>{
+          e.preventDefault(); msg.textContent='Sending…';
+          try{
+            const email = document.getElementById('reset_email').value.trim();
+            const { error } = await SB.auth.resetPasswordForEmail(email, { redirectTo: location.origin + '/login.html#type=recovery' });
+            if (error) throw error;
+            msg.textContent = 'Check your inbox for a reset link.';
+          }catch(ex){ msg.textContent = ex?.message || 'Could not send reset email.'; }
+        });
+      })();
     })();
   </script>
 </body>

--- a/record.html
+++ b/record.html
@@ -37,11 +37,7 @@
     .ok{color:#1b5e20}
     audio{width:100%; margin-top:10px}
   </style>
-  <script>
-    window.MEMOIR_SUPABASE_URL  = window.MEMOIR_SUPABASE_URL  || "https://fswxkujxusdozvmpyvzk.supabase.co";
-    window.MEMOIR_SUPABASE_ANON = window.MEMOIR_SUPABASE_ANON || "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZzd3hrdWp4dXNkb3p2bXB5dnprIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTgxMTk3MTYsImV4cCI6MjA3MzY5NTcxNn0.kNodFgDXi32w456e475fXvBi9eehX50HX_hVVTDBtXI";
-  </script>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="/js/memoir-supabase.js"></script>
 </head>
 <body>
   <div id="site-header"></div>
@@ -109,182 +105,203 @@
   <script src="/js/footer-loader.js"></script>
 
   <script>
-    const SB = supabase.createClient(window.MEMOIR_SUPABASE_URL, window.MEMOIR_SUPABASE_ANON);
-    let currentPlan = 'free';
-    function firstName(n){ return (n||'').trim().split(/\s+/)[0] || ''; }
-
-    // Personalize + plan note
-    (async function init(){
-      const title = document.getElementById('pageTitle');
-      const note  = document.getElementById('planNote');
-
-      const { data: { user } } = await SB.auth.getUser();
-      if (!user){ title.textContent='Record'; return; }
-
-      let profile = null;
-      try{
-        const { data } = await SB.from('profiles')
-          .select('full_name, subscription_plan')
-          .eq('user_id', user.id).single();
-        profile = data || {};
-      }catch{}
-
-      if (profile?.full_name){
-        title.textContent = 'Record, ' + firstName(profile.full_name);
+    (async function(){
+      const ensure = window.memoirEnsureSupabase ? window.memoirEnsureSupabase() : Promise.resolve(window.supabase);
+      let SB;
+      try {
+        await ensure;
+        const createClient = window.memoirCreateSupabaseClient;
+        SB = createClient
+          ? createClient()
+          : window.supabase.createClient(
+              window.MEMOIR_SUPABASE_URL || window.SUPABASE_URL,
+              window.MEMOIR_SUPABASE_ANON || window.SUPABASE_ANON_KEY
+            );
+        window.MEMOIR_SUPABASE_CLIENT = window.MEMOIR_SUPABASE_CLIENT || SB;
+      } catch (err) {
+        console.error('[record] supabase failed to load', err);
+        const note = document.getElementById('planNote');
+        if (note) note.textContent = 'Unable to connect to Supabase. Recording is unavailable.';
+        return;
       }
-      currentPlan = profile?.subscription_plan || 'free';
 
-      if (currentPlan === 'free'){
-        note.textContent = 'Free plan: recordings over 2 minutes are not allowed. Upgrade in Settings for higher limits.';
-      } else {
-        note.textContent = `Plan: ${currentPlan}`;
-      }
-    })();
+      let currentPlan = 'free';
+      function firstName(n){ return (n||'').trim().split(/\s+/)[0] || ''; }
 
-    // Prompts + tabs
-    const TOPIC_WORDS = {
-      en:["Childhood","Family","School","Work","Love","War","Travel","Traditions","Holidays","Lessons","Advice","Turning-points"],
-      fr:["Enfance","Famille","École","Travail","Amour","Guerre","Voyages","Traditions","Fêtes","Leçons","Conseils","Déclics"],
-      es:["Infancia","Familia","Escuela","Trabajo","Amor","Guerra","Viajes","Tradiciones","Fiestas","Lecciones","Consejos","Momentos clave"],
-      nl:["Jeugd","Familie","School","Werk","Liefde","Oorlog","Reizen","Tradities","Feestdagen","Lessen","Advies","Keerpunt"]
-    };
-    function renderPrompts(code){
-      const words=(TOPIC_WORDS[code]||TOPIC_WORDS.en);
-      const shuffled=[...words].sort(()=>Math.random()-0.5).slice(0,4);
-      const wrap=document.getElementById('prompts'); wrap.innerHTML='';
-      shuffled.forEach(w=>{
-        const b=document.createElement('button');
-        b.className='chip'; b.textContent=w;
-        b.onclick=()=>{ document.getElementById('title').value=w; };
-        wrap.appendChild(b);
-      });
-    }
-    function applyLangToRecord(code){ renderPrompts(code); }
-    window.addEventListener('memoir:lang',e=>applyLangToRecord(e.detail.code));
-    document.addEventListener('DOMContentLoaded',()=>applyLangToRecord(window.MEMOIR_I18N?.getLang?.()||'en'));
 
-    const tabFree=document.getElementById('tabFree');
-    const tabGuided=document.getElementById('tabGuided');
-    [tabFree,tabGuided].forEach(t=>t.onclick=()=>{
-      [tabFree,tabGuided].forEach(x=>x.classList.remove('active'));
-      t.classList.add('active');
-    });
+          // Personalize + plan note
+          (async function init(){
+            const title = document.getElementById('pageTitle');
+            const note  = document.getElementById('planNote');
 
-    // --- Recorder with auto-upload + story creation ---
-    const micBtn   = document.getElementById('mic');
-    const timerEl  = document.getElementById('timer');
-    const msgEl    = document.getElementById('recMsg');
-    const preview  = document.getElementById('preview');
-
-    let mediaStream = null;
-    let recorder    = null;
-    let chunks      = [];
-    let startedAt   = 0;
-    let tickHandle  = null;
-
-    function fmt(s){ s = Math.max(0, s|0); const m = (s/60)|0; const r = (s%60); return `${String(m).padStart(2,'0')}:${String(r).padStart(2,'0')}`; }
-
-    function startTimer() {
-      startedAt = Date.now();
-      clearInterval(tickHandle);
-      tickHandle = setInterval(()=>{
-        const sec = ((Date.now()-startedAt)/1000)|0;
-        timerEl.textContent = fmt(sec);
-        if (currentPlan === 'free' && sec >= 120) {
-          msgEl.className = 'muted warn';
-          msgEl.textContent = 'Reached 2-minute limit on Free plan — stopping.';
-          stopRecording();
-        }
-      }, 200);
-    }
-    function stopTimer() { clearInterval(tickHandle); tickHandle = null; }
-
-    async function startRecording(){
-      msgEl.className='muted';
-      msgEl.textContent='';
-      chunks = [];
-      preview.style.display = 'none';
-      preview.src = '';
-      try{
-        mediaStream = await navigator.mediaDevices.getUserMedia({ audio:true });
-        const mime = MediaRecorder.isTypeSupported('audio/webm') ? 'audio/webm' : undefined;
-        recorder = new MediaRecorder(mediaStream, mime ? { mimeType: mime } : undefined);
-
-        recorder.ondataavailable = (e)=>{ if (e.data?.size) chunks.push(e.data); };
-        recorder.onstop = async ()=>{
-          stopTimer();
-          mediaStream.getTracks().forEach(t=>t.stop());
-          const blob = new Blob(chunks, { type: recorder.mimeType || 'audio/webm' });
-          const url = URL.createObjectURL(blob);
-          preview.src = url;
-          preview.style.display = 'block';
-          micBtn.textContent = 'Record';
-          micBtn.classList.remove('pulse');
-          micBtn.setAttribute('aria-pressed','false');
-
-          // ---- AUTO-CREATE STORY + UPLOAD ----
-          try {
             const { data: { user } } = await SB.auth.getUser();
-            if (!user) { msgEl.className='muted warn'; msgEl.textContent='Please sign in again.'; return; }
+            if (!user){ title.textContent='Record'; return; }
 
-            // 1) Create story row
-            const title = document.getElementById('title').value.trim() || 'Untitled';
-            const when  = document.getElementById('when').value.trim() || null;
-            const notes = document.getElementById('notes').value.trim() || null;
+            let profile = null;
+            try{
+              const { data } = await SB.from('profiles')
+                .select('full_name, subscription_plan')
+                .eq('user_id', user.id).single();
+              profile = data || {};
+            }catch{}
 
-            const ins = await SB.from('stories')
-              .insert({ title, when_text: when, notes, visibility: 'private' })
-              .select()
-              .single();
-            if (ins.error) throw ins.error;
-            const story = ins.data;
+            if (profile?.full_name){
+              title.textContent = 'Record, ' + firstName(profile.full_name);
+            }
+            currentPlan = profile?.subscription_plan || 'free';
 
-            // 2) Upload audio to Storage
-            const path = `user/${user.id}/audio/${crypto.randomUUID()}.webm`;
-            const up = await SB.storage.from('story-media').upload(path, blob, { contentType: blob.type });
-            if (up.error) throw up.error;
+            if (currentPlan === 'free'){
+              note.textContent = 'Free plan: recordings over 2 minutes are not allowed. Upgrade in Settings for higher limits.';
+            } else {
+              note.textContent = `Plan: ${currentPlan}`;
+            }
+          })();
 
-            // 3) Link asset
-            const asset = await SB.from('story_assets')
-              .insert({ story_id: story.id, kind: 'audio', path, mime: blob.type })
-              .select()
-              .single();
-            if (asset.error) throw asset.error;
-
-            // 4) Optional: create empty text row for later AI rewrite
-            await SB.from('story_texts')
-              .insert({ story_id: story.id, original_text: null, rewritten_text: null })
-              .select().single().catch(()=>{ /* ignore if table not present */ });
-
-            msgEl.className = 'ok';
-            msgEl.innerHTML = `Uploaded and saved! <a href="/stories.html">Go to My Stories</a>`;
-          } catch (e) {
-            console.error(e);
-            msgEl.className='muted warn';
-            msgEl.textContent = 'Upload failed: ' + (e.message||e);
+          // Prompts + tabs
+          const TOPIC_WORDS = {
+            en:["Childhood","Family","School","Work","Love","War","Travel","Traditions","Holidays","Lessons","Advice","Turning-points"],
+            fr:["Enfance","Famille","École","Travail","Amour","Guerre","Voyages","Traditions","Fêtes","Leçons","Conseils","Déclics"],
+            es:["Infancia","Familia","Escuela","Trabajo","Amor","Guerra","Viajes","Tradiciones","Fiestas","Lecciones","Consejos","Momentos clave"],
+            nl:["Jeugd","Familie","School","Werk","Liefde","Oorlog","Reizen","Tradities","Feestdagen","Lessen","Advies","Keerpunt"]
+          };
+          function renderPrompts(code){
+            const words=(TOPIC_WORDS[code]||TOPIC_WORDS.en);
+            const shuffled=[...words].sort(()=>Math.random()-0.5).slice(0,4);
+            const wrap=document.getElementById('prompts'); wrap.innerHTML='';
+            shuffled.forEach(w=>{
+              const b=document.createElement('button');
+              b.className='chip'; b.textContent=w;
+              b.onclick=()=>{ document.getElementById('title').value=w; };
+              wrap.appendChild(b);
+            });
           }
-          // ------------------------------------
+          function applyLangToRecord(code){ renderPrompts(code); }
+          window.addEventListener('memoir:lang',e=>applyLangToRecord(e.detail.code));
+          document.addEventListener('DOMContentLoaded',()=>applyLangToRecord(window.MEMOIR_I18N?.getLang?.()||'en'));
 
-        };
+          const tabFree=document.getElementById('tabFree');
+          const tabGuided=document.getElementById('tabGuided');
+          [tabFree,tabGuided].forEach(t=>t.onclick=()=>{
+            [tabFree,tabGuided].forEach(x=>x.classList.remove('active'));
+            t.classList.add('active');
+          });
 
-        recorder.start(250);
-        startTimer();
-        micBtn.textContent = 'Stop';
-        micBtn.classList.add('pulse');
-        micBtn.setAttribute('aria-pressed','true');
+          // --- Recorder with auto-upload + story creation ---
+          const micBtn   = document.getElementById('mic');
+          const timerEl  = document.getElementById('timer');
+          const msgEl    = document.getElementById('recMsg');
+          const preview  = document.getElementById('preview');
 
-      }catch(e){
-        msgEl.className = 'muted warn';
-        msgEl.textContent = 'Microphone error: ' + (e.message || e);
-      }
-    }
-    function stopRecording(){
-      try { recorder?.state === 'recording' && recorder.stop(); } catch {}
-    }
-    micBtn.addEventListener('click', ()=>{
-      if (recorder && recorder.state === 'recording') stopRecording();
-      else startRecording();
-    });
+          let mediaStream = null;
+          let recorder    = null;
+          let chunks      = [];
+          let startedAt   = 0;
+          let tickHandle  = null;
+
+          function fmt(s){ s = Math.max(0, s|0); const m = (s/60)|0; const r = (s%60); return `${String(m).padStart(2,'0')}:${String(r).padStart(2,'0')}`; }
+
+          function startTimer() {
+            startedAt = Date.now();
+            clearInterval(tickHandle);
+            tickHandle = setInterval(()=>{
+              const sec = ((Date.now()-startedAt)/1000)|0;
+              timerEl.textContent = fmt(sec);
+              if (currentPlan === 'free' && sec >= 120) {
+                msgEl.className = 'muted warn';
+                msgEl.textContent = 'Reached 2-minute limit on Free plan — stopping.';
+                stopRecording();
+              }
+            }, 200);
+          }
+          function stopTimer() { clearInterval(tickHandle); tickHandle = null; }
+
+          async function startRecording(){
+            msgEl.className='muted';
+            msgEl.textContent='';
+            chunks = [];
+            preview.style.display = 'none';
+            preview.src = '';
+            try{
+              mediaStream = await navigator.mediaDevices.getUserMedia({ audio:true });
+              const mime = MediaRecorder.isTypeSupported('audio/webm') ? 'audio/webm' : undefined;
+              recorder = new MediaRecorder(mediaStream, mime ? { mimeType: mime } : undefined);
+
+              recorder.ondataavailable = (e)=>{ if (e.data?.size) chunks.push(e.data); };
+              recorder.onstop = async ()=>{
+                stopTimer();
+                mediaStream.getTracks().forEach(t=>t.stop());
+                const blob = new Blob(chunks, { type: recorder.mimeType || 'audio/webm' });
+                const url = URL.createObjectURL(blob);
+                preview.src = url;
+                preview.style.display = 'block';
+                micBtn.textContent = 'Record';
+                micBtn.classList.remove('pulse');
+                micBtn.setAttribute('aria-pressed','false');
+
+                // ---- AUTO-CREATE STORY + UPLOAD ----
+                try {
+                  const { data: { user } } = await SB.auth.getUser();
+                  if (!user) { msgEl.className='muted warn'; msgEl.textContent='Please sign in again.'; return; }
+
+                  // 1) Create story row
+                  const title = document.getElementById('title').value.trim() || 'Untitled';
+                  const when  = document.getElementById('when').value.trim() || null;
+                  const notes = document.getElementById('notes').value.trim() || null;
+
+                  const ins = await SB.from('stories')
+                    .insert({ title, when_text: when, notes, visibility: 'private' })
+                    .select()
+                    .single();
+                  if (ins.error) throw ins.error;
+                  const story = ins.data;
+
+                  // 2) Upload audio to Storage
+                  const path = `user/${user.id}/audio/${crypto.randomUUID()}.webm`;
+                  const up = await SB.storage.from('story-media').upload(path, blob, { contentType: blob.type });
+                  if (up.error) throw up.error;
+
+                  // 3) Link asset
+                  const asset = await SB.from('story_assets')
+                    .insert({ story_id: story.id, kind: 'audio', path, mime: blob.type })
+                    .select()
+                    .single();
+                  if (asset.error) throw asset.error;
+
+                  // 4) Optional: create empty text row for later AI rewrite
+                  await SB.from('story_texts')
+                    .insert({ story_id: story.id, original_text: null, rewritten_text: null })
+                    .select().single().catch(()=>{ /* ignore if table not present */ });
+
+                  msgEl.className = 'ok';
+                  msgEl.innerHTML = `Uploaded and saved! <a href="/stories.html">Go to My Stories</a>`;
+                } catch (e) {
+                  console.error(e);
+                  msgEl.className='muted warn';
+                  msgEl.textContent = 'Upload failed: ' + (e.message||e);
+                }
+                // ------------------------------------
+
+              };
+
+              recorder.start(250);
+              startTimer();
+              micBtn.textContent = 'Stop';
+              micBtn.classList.add('pulse');
+              micBtn.setAttribute('aria-pressed','true');
+
+            }catch(e){
+              msgEl.className = 'muted warn';
+              msgEl.textContent = 'Microphone error: ' + (e.message || e);
+            }
+          }
+          function stopRecording(){
+            try { recorder?.state === 'recording' && recorder.stop(); } catch {}
+          }
+          micBtn.addEventListener('click', ()=>{
+            if (recorder && recorder.state === 'recording') stopRecording();
+            else startRecording();
+          });
+    })();
   </script>
 </body>
 </html>

--- a/settings.html
+++ b/settings.html
@@ -23,12 +23,8 @@
     .warn{color:#8a1f17}
   </style>
 
-  <!-- Project keys -->
-  <script>
-    window.MEMOIR_SUPABASE_URL  = window.MEMOIR_SUPABASE_URL  || "https://fswxkujxusdozvmpyvzk.supabase.co";
-    window.MEMOIR_SUPABASE_ANON = window.MEMOIR_SUPABASE_ANON || "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZzd3hrdWp4dXNkb3p2bXB5dnprIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTgxMTk3MTYsImV4cCI6MjA3MzY5NTcxNn0.kNodFgDXi32w456e475fXvBi9eehX50HX_hVVTDBtXI";
-  </script>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <!-- Shared Supabase config -->
+  <script src="/js/memoir-supabase.js"></script>
 </head>
 <body>
   <div id="site-header"></div>
@@ -110,69 +106,78 @@
   <script src="/js/header-loader.js"></script>
   <script src="/js/footer-loader.js"></script>
   <script>
-    // Create client with session persistence + URL detection
-    const SB = supabase.createClient(
-      window.MEMOIR_SUPABASE_URL,
-      window.MEMOIR_SUPABASE_ANON,
-      { auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true } }
-    );
-
-    const pageTitle    = document.getElementById('pageTitle');
-    const accountBlurb = document.getElementById('accountBlurb');
-    const accountActs  = document.getElementById('accountActions');
-    const subBlurb     = document.getElementById('subBlurb');
-
-    function firstName(full){ return (full||'').trim().split(/\s+/)[0] || ''; }
-
-    async function renderSettings(){
-      // Read session
-      const { data: { user }, error } = await SB.auth.getUser();
-
-      if (!user || error) {
-        pageTitle.textContent = 'Settings';
-        accountBlurb.innerHTML = 'You are <strong class="warn">not signed in</strong>.';
-        accountActs.innerHTML = `
-          <a class="pill primary" href="/login.html">Sign in</a>
-        `;
-        subBlurb.textContent = 'Sign in to see or change your plan.';
+    (async function(){
+      const ensure = window.memoirEnsureSupabase ? window.memoirEnsureSupabase() : Promise.resolve(window.supabase);
+      let SB;
+      try {
+        await ensure;
+        const createClient = window.memoirCreateSupabaseClient;
+        SB = createClient
+          ? createClient({ auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true } })
+          : window.supabase.createClient(
+              window.MEMOIR_SUPABASE_URL || window.SUPABASE_URL,
+              window.MEMOIR_SUPABASE_ANON || window.SUPABASE_ANON_KEY,
+              { auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true } }
+            );
+        window.MEMOIR_SUPABASE_CLIENT = SB;
+      } catch (err) {
+        console.error('[settings] supabase failed to load', err);
+        const blurb = document.getElementById('accountBlurb');
+        if (blurb) blurb.textContent = 'Unable to connect to your account. Please refresh the page.';
         return;
       }
 
-      // Fetch profile for name + plan
-      let profile = null;
-      try {
-        const { data } = await SB
-          .from('profiles')
-          .select('full_name, subscription_plan')
-          .eq('user_id', user.id)
-          .single();
-        profile = data || {};
-      } catch {}
+      const pageTitle    = document.getElementById('pageTitle');
+      const accountBlurb = document.getElementById('accountBlurb');
+      const accountActs  = document.getElementById('accountActions');
+      const subBlurb     = document.getElementById('subBlurb');
 
-      const full = profile?.full_name || user.email || 'Your account';
-      pageTitle.textContent = 'Settings';
-      accountBlurb.innerHTML = `Signed in as <strong class="ok">${full}</strong> (${user.email})`;
-      accountActs.innerHTML = `
-        <a class="pill" href="/stories.html">My Stories</a>
-        <a class="pill" href="/record.html">Record</a>
-        <button class="pill" id="signOutBtn">Sign out</button>
-      `;
-      document.getElementById('signOutBtn').onclick = async ()=>{
-        await SB.auth.signOut();
-        location.href = '/login.html';
-      };
+      function firstName(full){ return (full||'').trim().split(/\s+/)[0] || ''; }
 
-      // Plan status
-      const plan = profile?.subscription_plan || 'free';
-      subBlurb.textContent = `Current plan: ${plan}`;
-    }
+      async function renderSettings(){
+        const { data: { user }, error } = await SB.auth.getUser();
 
-    // Render on load and when we regain focus (helps after email confirmation)
-    document.addEventListener('DOMContentLoaded', renderSettings);
-    window.addEventListener('focus', renderSettings);
+        if (!user || error) {
+          pageTitle.textContent = 'Settings';
+          accountBlurb.innerHTML = 'You are <strong class="warn">not signed in</strong>.';
+          accountActs.innerHTML = `
+            <a class="pill primary" href="/login.html">Sign in</a>
+          `;
+          subBlurb.textContent = 'Sign in to see or change your plan.';
+          return;
+        }
 
-    // Also re-render if the auth state changes on this tab
-    SB.auth.onAuthStateChange((_event, _session) => { renderSettings(); });
+        let profile = null;
+        try {
+          const { data } = await SB
+            .from('profiles')
+            .select('full_name, subscription_plan')
+            .eq('user_id', user.id)
+            .single();
+          profile = data || {};
+        } catch {}
+
+        const full = profile?.full_name || user.email || 'Your account';
+        pageTitle.textContent = 'Settings';
+        accountBlurb.innerHTML = `Signed in as <strong class="ok">${full}</strong> (${user.email})`;
+        accountActs.innerHTML = `
+          <a class="pill" href="/stories.html">My Stories</a>
+          <a class="pill" href="/record.html">Record</a>
+          <button class="pill" id="signOutBtn">Sign out</button>
+        `;
+        document.getElementById('signOutBtn').onclick = async ()=>{
+          await SB.auth.signOut();
+          location.href = '/login.html';
+        };
+
+        const plan = profile?.subscription_plan || 'free';
+        subBlurb.textContent = `Current plan: ${plan}`;
+      }
+
+      document.addEventListener('DOMContentLoaded', renderSettings);
+      window.addEventListener('focus', renderSettings);
+      SB.auth.onAuthStateChange(() => { renderSettings(); });
+    })();
   </script>
 </body>
 </html>

--- a/stories.html
+++ b/stories.html
@@ -28,11 +28,7 @@
     input[type=email]{padding:10px 12px;border-radius:12px;border:1px solid rgba(0,0,0,.15);background:#fff}
     .muted{color:var(--muted)}
   </style>
-  <script>
-    window.MEMOIR_SUPABASE_URL  = window.MEMOIR_SUPABASE_URL  || "https://fswxkujxusdozvmpyvzk.supabase.co";
-    window.MEMOIR_SUPABASE_ANON = window.MEMOIR_SUPABASE_ANON || "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZzd3hrdWp4dXNkb3p2bXB5dnprIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTgxMTk3MTYsImV4cCI6MjA3MzY5NTcxNn0.kNodFgDXi32w456e475fXvBi9eehX50HX_hVVTDBtXI";
-  </script>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="/js/memoir-supabase.js"></script>
 </head>
 <body>
   <div id="site-header"></div>
@@ -71,95 +67,113 @@
   <script src="/js/header-loader.js"></script>
   <script src="/js/footer-loader.js"></script>
   <script>
-    const SB = supabase.createClient(window.MEMOIR_SUPABASE_URL, window.MEMOIR_SUPABASE_ANON);
-    const listEl = document.getElementById('storiesList');
-    function firstName(full){ return (full||'').trim().split(/\s+/)[0] || ''; }
-
-    async function loadEverything(){
-      const { data: { user } } = await SB.auth.getUser();
-      if (!user){
-        document.getElementById('pageTitle').textContent = 'My Stories';
-        listEl.innerHTML = '<div class="empty">Please <a href="/login.html">sign in</a>.</div>';
+    (async function(){
+      const ensure = window.memoirEnsureSupabase ? window.memoirEnsureSupabase() : Promise.resolve(window.supabase);
+      let SB;
+      try {
+        await ensure;
+        const createClient = window.memoirCreateSupabaseClient;
+        SB = createClient
+          ? createClient()
+          : window.supabase.createClient(
+              window.MEMOIR_SUPABASE_URL || window.SUPABASE_URL,
+              window.MEMOIR_SUPABASE_ANON || window.SUPABASE_ANON_KEY
+            );
+        window.MEMOIR_SUPABASE_CLIENT = window.MEMOIR_SUPABASE_CLIENT || SB;
+      } catch (err) {
+        console.error('[stories] supabase failed to load', err);
+        const listEl = document.getElementById('storiesList');
+        if (listEl) listEl.innerHTML = '<div class="empty">Unable to load stories. Please refresh.</div>';
         return;
       }
-      // Profile
-      try{
-        const { data } = await SB.from('profiles').select('full_name').eq('user_id', user.id).single();
-        if (data?.full_name) document.getElementById('pageTitle').textContent = 'My Stories, ' + firstName(data.full_name);
-      }catch{}
 
-      // Stories
-      try{
-        const { data, error } = await SB.from('stories').select('id,title,created_at,visibility').order('created_at',{ascending:false});
-        if (error) throw error;
-        document.getElementById('countStories').textContent = String(data?.length || 0);
-        if (!data || !data.length){
-          listEl.innerHTML = '<div class="empty">No stories yet. Record your first one!</div>';
-        } else {
-          listEl.innerHTML = data.map(s=>{
-            const when = new Date(s.created_at).toLocaleString();
-            const title = s.title || 'Untitled';
-            const vis = s.visibility || 'private';
-            return `
-              <article class="story-card" data-id="${s.id}">
-                <h3>${title}</h3>
-                <div class="meta">${when} · ${vis}</div>
-                <div class="actions">
-                  <button class="pill" data-rewrite="1">Rewrite with AI</button>
-                  <a class="pill" href="/record.html">Continue</a>
-                </div>
-                <div class="muted" data-msg style="margin-top:6px;min-height:1.1em"></div>
-              </article>
-            `;
-          }).join('');
-          // wire rewrite buttons
-          listEl.querySelectorAll('[data-rewrite]').forEach(btn=>{
-            btn.addEventListener('click', async ()=>{
-              const card = btn.closest('.story-card');
-              const id = card?.dataset?.id;
-              const msg = card?.querySelector('[data-msg]');
-              if (!id || !msg) return;
-              msg.textContent='Rewriting…';
-              try{
-                const res = await fetch('/api/rewrite', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ story_id: id }) });
-                if (!res.ok) throw new Error('Server error');
-                const json = await res.json();
-                msg.textContent = json.message || 'Done.';
-              }catch(e){ msg.textContent = 'Could not rewrite: ' + (e.message||e); }
-            });
-          });
+      const listEl = document.getElementById('storiesList');
+      function firstName(full){ return (full||'').trim().split(/\s+/)[0] || ''; }
+
+      async function loadEverything(){
+        const { data: { user } } = await SB.auth.getUser();
+        if (!user){
+          document.getElementById('pageTitle').textContent = 'My Stories';
+          listEl.innerHTML = '<div class="empty">Please <a href="/login.html">sign in</a>.</div>';
+          return;
         }
-      }catch(e){
-        listEl.innerHTML = `<div class="empty">Could not load stories: ${e.message}</div>`;
+
+        try{
+          const { data } = await SB.from('profiles').select('full_name').eq('user_id', user.id).single();
+          if (data?.full_name) document.getElementById('pageTitle').textContent = 'My Stories, ' + firstName(data.full_name);
+        }catch{}
+
+        try{
+          const { data, error } = await SB.from('stories').select('id,title,created_at,visibility').order('created_at',{ascending:false});
+          if (error) throw error;
+          document.getElementById('countStories').textContent = String(data?.length || 0);
+          if (!data || !data.length){
+            listEl.innerHTML = '<div class="empty">No stories yet. Record your first one!</div>';
+          } else {
+            listEl.innerHTML = data.map(s=>{
+              const when = new Date(s.created_at).toLocaleString();
+              const title = s.title || 'Untitled';
+              const vis = s.visibility || 'private';
+              return `
+                <article class="story-card" data-id="${s.id}">
+                  <h3>${title}</h3>
+                  <div class="meta">${when} · ${vis}</div>
+                  <div class="actions">
+                    <button class="pill" data-rewrite="1">Rewrite with AI</button>
+                    <a class="pill" href="/record.html">Continue</a>
+                  </div>
+                  <div class="muted" data-msg style="margin-top:6px;min-height:1.1em"></div>
+                </article>
+              `;
+            }).join('');
+            listEl.querySelectorAll('[data-rewrite]').forEach(btn=>{
+              btn.addEventListener('click', async ()=>{
+                const card = btn.closest('.story-card');
+                const id = card?.dataset?.id;
+                const msg = card?.querySelector('[data-msg]');
+                if (!id || !msg) return;
+                msg.textContent='Rewriting…';
+                try{
+                  const res = await fetch('/api/rewrite', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ story_id: id }) });
+                  if (!res.ok) throw new Error('Server error');
+                  const json = await res.json();
+                  msg.textContent = json.message || 'Done.';
+                }catch(e){ msg.textContent = 'Could not rewrite: ' + (e.message||e); }
+              });
+            });
+          }
+        }catch(e){
+          listEl.innerHTML = `<div class="empty">Could not load stories: ${e.message}</div>`;
+        }
+
+        try{
+          const { data, error } = await SB.from('family_invites').select('id,status').order('created_at',{ascending:false});
+          if (error) throw error;
+          const accepted = (data||[]).filter(i => (i.status||'pending') !== 'revoked');
+          document.getElementById('countFamily').textContent = String(accepted.length);
+        }catch{}
       }
 
-      // Family count (optional)
-      try{
-        const { data, error } = await SB.from('family_invites').select('id,status').order('created_at',{ascending:false});
-        if (error) throw error;
-        const accepted = (data||[]).filter(i => (i.status||'pending') !== 'revoked');
-        document.getElementById('countFamily').textContent = String(accepted.length);
-      }catch{}
-    }
+      document.getElementById('inviteBtn').addEventListener('click', async ()=>{
+        const msg = document.getElementById('inviteMsg');
+        const email = document.getElementById('inviteEmail').value.trim();
+        if (!email){ msg.textContent='Enter an email.'; return; }
+        const { data: { user } } = await SB.auth.getUser();
+        if (!user){ msg.textContent='Please sign in first.'; return; }
+        msg.textContent='Sending…';
+        try{
+          const res = await SB.from('family_invites').insert({ owner_id: user.id, email, status:'pending' });
+          if (res.error) throw res.error;
+          msg.textContent='Invite saved. We’ll email instructions when mail is configured.';
+          document.getElementById('inviteEmail').value='';
+          loadEverything();
+        }catch(e){ msg.textContent = 'Could not save invite: ' + e.message; }
+      });
 
-    // Invite action
-    document.getElementById('inviteBtn').addEventListener('click', async ()=>{
-      const msg = document.getElementById('inviteMsg');
-      const email = document.getElementById('inviteEmail').value.trim();
-      if (!email){ msg.textContent='Enter an email.'; return; }
-      const { data: { user } } = await SB.auth.getUser();
-      if (!user){ msg.textContent='Please sign in first.'; return; }
-      msg.textContent='Sending…';
-      try{
-        const res = await SB.from('family_invites').insert({ owner_id: user.id, email, status:'pending' });
-        if (res.error) throw res.error;
-        msg.textContent='Invite saved. We’ll email instructions when mail is configured.';
-        document.getElementById('inviteEmail').value='';
-        loadEverything();
-      }catch(e){ msg.textContent = 'Could not save invite: ' + e.message; }
-    });
-
-    document.addEventListener('DOMContentLoaded', loadEverything);
+      document.addEventListener('DOMContentLoaded', loadEverything);
+      window.addEventListener('focus', loadEverything);
+      SB.auth.onAuthStateChange(()=>{ loadEverything(); });
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a shared Supabase bootstrap helper that standardises the Memoir project URL/key and lazy-loads the library
- update the header session pill plus login, settings, stories, record, and auth flows to create clients through the shared helper with clearer error handling
- include the shared helper on all public pages so Supabase configuration is consistent across the app

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d196d2352c832695bf6f050b82ad95