### PR TITLE
Fix API integrations for transcribe and rewrite

### DIFF
--- a/api/rewrite.js
+++ b/api/rewrite.js
@@ -43,7 +43,7 @@ export default async function handler(req, res) {
     if (!story_id) return res.status(400).json({ error: 'Provide either text or story_id' });
 
     const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
-    const SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+    const SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
     if (!SUPABASE_URL || !SERVICE_ROLE) return res.status(500).json({ error: 'Supabase env missing' });
 
     const sb = createClient(SUPABASE_URL, SERVICE_ROLE, { auth: { persistSession: false } });

--- a/api/transcribe-chunk.js
+++ b/api/transcribe-chunk.js
@@ -23,7 +23,8 @@ export default async function handler(req,res){
       return res.status(400).json({ error:'chunk_failed', detail: t });
     }
     const out = await r.json(); // { text: "..." }
-    res.json({ partial: out.text || '' });
+    const text = out.text || '';
+    res.json({ text, partial: text });
   }catch(e){
     console.error(e);
     res.status(500).json({ error:String(e) });


### PR DESCRIPTION
## Summary
- ensure the chunk transcription endpoint returns a `text` field for the client
- support both Supabase service-role env variable names in the rewrite API

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d196bbcd4083269cb92d86c96e1f1f